### PR TITLE
Add optional `offline` prop for offline picker use

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Output should be a Language Picker when entered opens a dialog
 | displayName\* | DisplayName          | function to control display of name |
 | setInfo\*  | (tag: LangTag) => void  | callback to receive tag information |
 | disabled\* | boolean                 | true if control disabled            |
-| hideLink\* | boolean                 | true if Code Explained link hidden  |
+| offline\*  | boolean                 | true if picker in offline setting   |
 | t          | ILanguagePickerStrings  | localization strings (see below)    |
 
 \* parameters marked with an asterisk are optional

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Output should be a Language Picker when entered opens a dialog
 | setInfo\*  | (tag: LangTag) => void  | callback to receive tag information |
 | disabled\* | boolean                 | true if control disabled            |
 | t          | ILanguagePickerStrings  | localization strings (see below)    |
+| hideLink\* | boolean                 | true if Code Explained link hidden  |
 
 \* parameters marked with an asterisk are optional
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Output should be a Language Picker when entered opens a dialog
 | displayName\* | DisplayName          | function to control display of name |
 | setInfo\*  | (tag: LangTag) => void  | callback to receive tag information |
 | disabled\* | boolean                 | true if control disabled            |
-| t          | ILanguagePickerStrings  | localization strings (see below)    |
 | hideLink\* | boolean                 | true if Code Explained link hidden  |
+| t          | ILanguagePickerStrings  | localization strings (see below)    |
 
 \* parameters marked with an asterisk are optional
 

--- a/src/LanguagePicker.tsx
+++ b/src/LanguagePicker.tsx
@@ -67,10 +67,11 @@ interface IProps extends IStateProps {
   setInfo?: (tag: LangTag) => void;
   setDir?: (rtl: boolean) => void;
   disabled?: boolean;
+  hideLink?: boolean;
 }
 
 export const LanguagePicker = (props: IProps) => {
-  const { disabled } = props;
+  const { disabled, hideLink } = props;
   const { value, name, font, setCode, setName, setFont, setInfo, setDir, t } =
     props;
   const { displayName } = props;
@@ -535,13 +536,15 @@ export const LanguagePicker = (props: IProps) => {
           />
         </DialogContent>
         <DialogActions>
-          <a
-            href="https://www.w3.org/International/questions/qa-choosing-language-tags"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Typography>{t.codeExplained}</Typography>
-          </a>
+          {!hideLink && (
+            <a
+              href="https://www.w3.org/International/questions/qa-choosing-language-tags"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Typography>{t.codeExplained}</Typography>
+            </a>
+          )}
           {curName !== '' && (
             <Tooltip title={t.changeName ?? 'Change name'}>
               <IconButton

--- a/src/LanguagePicker.tsx
+++ b/src/LanguagePicker.tsx
@@ -67,11 +67,11 @@ interface IProps extends IStateProps {
   setInfo?: (tag: LangTag) => void;
   setDir?: (rtl: boolean) => void;
   disabled?: boolean;
-  hideLink?: boolean;
+  offline?: boolean;
 }
 
 export const LanguagePicker = (props: IProps) => {
-  const { disabled, hideLink } = props;
+  const { disabled, offline } = props;
   const { value, name, font, setCode, setName, setFont, setInfo, setDir, t } =
     props;
   const { displayName } = props;
@@ -536,7 +536,7 @@ export const LanguagePicker = (props: IProps) => {
           />
         </DialogContent>
         <DialogActions>
-          {!hideLink && (
+          {!offline && (
             <a
               href="https://www.w3.org/International/questions/qa-choosing-language-tags"
               target="_blank"


### PR DESCRIPTION
This pr adds a prop to allow hiding unusable links for when the language picker is being used in an offline app (_a la_ https://github.com/sillsdev/TheCombine/issues/2232#issuecomment-1701861064).