### PR TITLE
Update recommanded (and tests) from Charis SIL to Charis

### DIFF
--- a/src/LanguagePicker.tsx
+++ b/src/LanguagePicker.tsx
@@ -206,7 +206,7 @@ export const LanguagePicker = (props: IProps) => {
   };
 
   const safeFonts = [
-    { value: 'charissil', label: 'Charis SIL (Recommended)', rtl: false },
+    { value: 'charis', label: 'Charis (Recommended)', rtl: false },
     { value: 'annapurnasil', label: 'Annapurna SIL (Indic)', rtl: false },
     { value: 'scheherazadenew', label: 'Scheherazade New (Arabic)', rtl: true },
     { value: 'notosanstc', label: 'Noto Sans TC (Chinese)', rtl: false },

--- a/src/__tests__/languagePicker.test.tsx
+++ b/src/__tests__/languagePicker.test.tsx
@@ -77,7 +77,7 @@ describe('LanguagePicker', () => {
     const props = {
       value: 'en',
       name: 'English',
-      font: 'charissil',
+      font: 'charis',
       t: languagePickerStrings_en,
     };
     const { container } = render(<LanguagePicker {...props} />);
@@ -109,7 +109,7 @@ describe('LanguagePicker', () => {
     const props = {
       value: 'en',
       name: 'English',
-      font: 'charissil',
+      font: 'charis',
       t: languagePickerStrings_en,
     };
     const { container } = render(<LanguagePicker {...props} />);
@@ -121,7 +121,7 @@ describe('LanguagePicker', () => {
     const props = {
       value: 'en',
       name: 'English',
-      font: 'charissil',
+      font: 'charis',
       t: languagePickerStrings_en,
     };
     const { container } = render(<LanguagePicker {...props} />);


### PR DESCRIPTION
The update to the `safeFonts` recommended font is to match WSTech's update from Charis SIL 6 to Charis 7, which is reflected in this repo's generated `src/data/scriptFontIndex.ts`.

The test update in this pr is definitely optional.